### PR TITLE
Fix overlap issues for messages with attached content

### DIFF
--- a/MomotalkSource.theme.css
+++ b/MomotalkSource.theme.css
@@ -456,7 +456,7 @@
 		display: flex;
 		flex-direction: column;
 
-		.markup_f8f345.messageContent_f9f2ca {
+		.markup_f8f345 {
 			display: inline-block;
 			padding: 5px 15px;
 			margin-left: 0px;
@@ -473,10 +473,19 @@
 	}
 
 	.container_b558d0 {
-		background-color: var(--messagebubble);
-		border-radius: var(--momo-messages-border-radius);
-		width: fit-content;
-		padding: 20px;
+		padding: 0;
+	
+		>.visualMediaItemContainer_cda674, .inlineMediaEmbed_b0068a {
+			height: initial;
+			background-color: var(--messagebubble);
+			border-radius: var(--momo-messages-border-radius);
+			width: fit-content;
+			padding: 20px;
+		}
+
+		.reaction_ec6b19.reactionMe_ec6b19 .reactionCount_ec6b19 {
+			color: var(--brand-560);
+		}
 	}
 }
 
@@ -524,7 +533,7 @@
 			right: var(--custom-message-margin-horizontal);
 		}
 
-		.markup_f8f345.messageContent_f9f2ca {
+		.markup_f8f345 {
 			right: 9px;
 
 			&::after {

--- a/MomotalkSource.theme.css
+++ b/MomotalkSource.theme.css
@@ -499,11 +499,12 @@
 
 		.markup_f8f345.messageContent_f9f2ca {
 			margin-left: 11px;
+			left: 2px;
 		}
 	}
 
 	.container_b558d0 {
-		left: 10px;
+		left: 13px;
 	}
 }
 
@@ -513,8 +514,12 @@
 	align-items: end;
 
 	/* Flip discord paddings */
-	padding-right: var(--custom-message-margin-left-content-cozy) !important;
 	padding-left: 48px;
+	padding-right: var(--custom-message-margin-horizontal) !important;
+
+	&.cozy_f9f2ca {
+		padding-right: var(--custom-message-margin-left-content-cozy) !important;
+	}
 
 	&.groupStart_d5deea::after {
 		transform: rotate(0deg);
@@ -532,12 +537,12 @@
 		}
 
 		.markup_f8f345.messageContent_f9f2ca {
-			right: 8px;
+			right: 9px;
 		}
 	}
 
 	.container_b558d0 {
-		right: 8px;
+		right: 9px;
 	}
 
 	.timestamp_f9f2ca {

--- a/MomotalkSource.theme.css
+++ b/MomotalkSource.theme.css
@@ -1,24 +1,22 @@
-
-
 /* Change Colors Here!!!! */
 :root {
 	--background-primary: #FFFFFF;
-	
+
 	--momotalkbanner: #FB90A4;
-	
+
 	--senseimessagebubble: #4A8AC8;
 	--messagebubble: #4C5B6F;
-	
+
 	--text-link: #CCD3FF;
-	
+
 	--messagefontcolor: #FFFFFF;
-	
+
 	--username: #3F444A;
-	
+
 	--sidebar: #505C72;
-	
+
 	--topbar: #E7F0F7;
-	
+
 	--searchbars: #303C51;
 
 	--callcolor: #505C72;
@@ -26,12 +24,10 @@
 
 	--callbuttons: #303C51;
 	--hangup: #FB90A4;
-	
+
 	--bgimage: url('your image url here.png');
 
 	--settingsfontcolor: #000000;
-	
-
 }
 
 
@@ -40,182 +36,110 @@
 
 
 /*Home Image*/
-.wrapper_c5f96a:hover .childWrapper_f90abb, .childWrapper_f90abb {background-color: transparent;} /*replace with colour if you want a colour behind your image */
-#app-mount .tutorialContainer_f9623d .childWrapper_f90abb {
-    background-image: url('https://i.imgur.com/UEiRGq4.png');
-/*    height: 150%;
-    width: 150%;*/
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: center;
+.wrapper_c5f96a:hover .childWrapper_f90abb,
+.childWrapper_f90abb {
+	background-color: transparent;
 }
-.childWrapper_f90abb svg {display: none;}
+
+/*replace with colour if you want a colour behind your image */
+#app-mount .tutorialContainer_f9623d .childWrapper_f90abb {
+	background-image: url('https://i.imgur.com/UEiRGq4.png');
+	background-repeat: no-repeat;
+	background-size: cover;
+	background-position: center;
+}
+
+.childWrapper_f90abb svg {
+	display: none;
+}
 
 .childWrapper_f90abb.childWrapperNoHoverBg_f90abb {
 	background-color: transparent !important;
 }
 
-.listItemWrapper_dfb2f8.selected_dfb2f8{
-	background-color: #66778B !important;	
+.listItemWrapper_dfb2f8.selected_dfb2f8 {
+	background-color: #66778B !important;
 }
 
 /* That annoying hole next to server names */
-[class^=sidebar_] { border-radius: 0 !important; }
+[class^=sidebar_] {
+	border-radius: 0 !important;
+}
 
 /* and that weird gradient in the top bar */
 .theme-dark .children_fc4f04:after {
-    background: transparent;
+	background: transparent;
 }
 
 /* Now Typing */
 .typing_d7ebeb {
- color:var(--username); 	
+	color: var(--username);
 }
 
 /* Custom Background Image */
 .chatContent_a7d72e {
-  background-image:var(--bgimage);
-  background-size: cover;
+	background-image: var(--bgimage);
+	background-size: cover;
 }
-
 
 /* Message font */
-.markup_f8f345{
-    color:var(--messagefontcolor);
+.markup_f8f345 {
+	color: var(--messagefontcolor);
 }
-
 
 /* Usernames */
-.username_f9f2ca{
-    color:var(--username) !important; 
-        font-weight: bold;
-        margin-left: 8px;
-
-}
-
-/* Message container */
-.contents_f9f2ca .markup_f8f345 {
-    display: inline-block;
-    z-index: 1; 
-	background-color:var(--messagebubble);
-    border-radius: 10px;
-    padding: 5px 15px; 
-    margin-left: 12px;     
-	max-width: 600px;
-}
-
-
-
-
-/* Message container for images */
-[data-is-self="false"] .container_b558d0 {
-
-    bottom: 5px;
-    
-	background-color:var(--messagebubble);
-    border-radius: 10px;
-    padding: 5px 15px; 
-    padding-top: 20px;
-    padding-bottom: 20px;
-    margin-bottom: -20px;
-    margin-left: 12px;  
-    transform: translate(0px, -12px);
-}
-
-
-
-/* Little arrow in message containers  */
-[data-is-self="false"] .groupStart_d5deea::after {
-
-    content: "\25BA";
-	color:var(--messagebubble);
-    font-size: 15px;
-    display: block;
-    transform: rotate(180deg);
-    position: absolute;
-    left: 74px;
-    top: 28px;
-    border-radius: 5px;
-}
-
-/* Little arrow in message containers for welcome messages and all*/
-.isSystemMessage_f9f2ca::after{
-
-    content: "\25BA";
-	color:var(--messagebubble);
-    font-size: 15px;
-    display: block;
-    transform: rotate(180deg);
-    position: absolute;
-    left: 74px;
-    top: 10px !important;
-    border-radius: 5px;
-}
-
-/* Little arrow in message containers for replies!*/
-[data-is-self="false"] .hasReply_f9f2ca::after {
-
-    content: "\25BA";
-	color:var(--messagebubble);
-    font-size: 15px;
-    display: block;
-    transform: rotate(180deg);
-    position: absolute;
-    left: 75px;
-    top: 53px;
-    border-radius: 4px;
+.username_f9f2ca {
+	color: var(--username) !important;
+	font-weight: bold;
+	margin-left: 8px;
 }
 
 /* Avatar size */
-
-.avatar_f9f2ca{
- height: 55px;
- width: 55px;
+.avatar_f9f2ca {
+	height: 55px;
+	width: 55px;
 }
 
 /* Decoration size */
-
-.avatarDecoration_f9f2ca{
- height: 65px;
- width: 65px;
+.avatarDecoration_f9f2ca {
+	height: 65px;
+	width: 65px;
 }
 
 /* Title Bar */
 .titleBar_a934d8 {
-background-color:var(--momotalkbanner);
-height: 37px;
-margin-top: 1px;
+	background-color: var(--momotalkbanner);
+	height: 37px;
+	margin-top: 1px;
 }
 
 .winButton_a934d8 {
-    color: white;
-    height: 27px;
-    width:30px;
-    right: 10px;
-    top: 2px;
-    margin-left: 31px;
-    transform: scale(1.5); 
+	color: white;
+	height: 27px;
+	width: 30px;
+	right: 10px;
+	top: 2px;
+	margin-left: 31px;
+	transform: scale(1.5);
 }
-
-
 
 /* Watermark*/
 .wordmark_a934d8 svg {
-display:none;
+	display: none;
 }
 
 .wordmark_a934d8::after {
-    top: -59px;
-    left: 1px;
-    position: relative;
-    content: "";
-    display: inline-block;
-    width: 150px; 
-    height: 150px;
-    background-image: url(https://i.imgur.com/7PHPCpk.png);
-    background-size: contain; 
-    background-repeat: no-repeat; 
-    background-position: center; 
+	top: -59px;
+	left: 1px;
+	position: relative;
+	content: "";
+	display: inline-block;
+	width: 150px;
+	height: 150px;
+	background-image: url(https://i.imgur.com/7PHPCpk.png);
+	background-size: contain;
+	background-repeat: no-repeat;
+	background-position: center;
 }
 
 /*Links Color*/
@@ -223,51 +147,49 @@ display:none;
 
 /* Friends Tab */
 .theme-dark.images-dark.container_fc4f04.themed_fc4f04 {
-		background-color: #E7F0F7;
+	background-color: #E7F0F7;
 }
-.username_f3939d{
+
+.username_f3939d {
 	color: #3A4446 !important;
 }
 
 .scroller_bf550a {
-  background-image: url('https://i.imgur.com/OJgUygB.png'); 
-  background-size: contain; 
-  background-repeat: no-repeat; 
-  background-position: bottom; 
-
+	background-image: url('https://i.imgur.com/OJgUygB.png');
+	background-size: contain;
+	background-repeat: no-repeat;
+	background-position: bottom;
 }
 
-.itemCard_f02fcf  {
-	background-color:var(--topbar);
+.itemCard_f02fcf {
+	background-color: var(--topbar);
 }
 
 /* Scrollbar */
-.scroller_e2e187::-webkit-scrollbar {
-    width: 15px; 
+.scroller_e2e187 {
+	::-webkit-scrollbar {
+		width: 15px;
+	}
+
+	::-webkit-scrollbar-track {
+		background-color: #E1E4E6;
+	}
+
+	::-webkit-scrollbar-thumb {
+		background-color: #B0B0B0;
+		border-radius: 8px;
+	}
 }
-
-
-.scroller_e2e187::-webkit-scrollbar-track {
-    background-color: #E1E4E6; 
-}
-
-.scroller_e2e187::-webkit-scrollbar-thumb {
-    background-color: #B0B0B0; 
-    border-radius: 8px; 
-}
-
 
 /* Channel bar */
-
-.title_a7d72e.container_fc4f04.themed_fc4f04{
-  background-color:var(--topbar) !important;
+.title_a7d72e.container_fc4f04.themed_fc4f04 {
+	background-color: var(--topbar) !important;
 
 }
 
 /* New Messages */
-
 .newMessagesBar_cf58b5 {
-  background-color:var(--momotalkbanner) !important;
+	background-color: var(--momotalkbanner) !important;
 
 }
 
@@ -275,105 +197,119 @@ display:none;
 	color: #4ABDD8 !important;
 }
 
-
-.title_fc4f04{
-  color: black;
+.title_fc4f04 {
+	color: black;
 }
 
 .name_fd6364 {
-	color:var(--messagefontcolor) !important;
+	color: var(--messagefontcolor) !important;
 }
+
 .icon_fc4f04 {
-  color: #4ABDD8;
+	color: #4ABDD8;
 }
 
 
 /* Server list */
 .scroller_fea3ef {
-background-color:var(--sidebar) !important;
-	
+	background-color: var(--sidebar) !important;
 }
 
 .guildSeparator_d0c57e {
 	background-color: #4ABDD8;
-    width: 50px;
-	
+	width: 50px;
 }
 
 /* Calls */
 .root_dd069c {
- background-color:var(--callcolor) !important;
-  background-image:var(--callimage) !important;
-  background-size: cover;
-  background-position: top;
-}
-.red_ef18ee {
-	background-color:var(--hangup) !important;
-}
-.red_ef18ee:hover {
-    filter: brightness(0.8);
+	background-color: var(--callcolor) !important;
+	background-image: var(--callimage) !important;
+	background-size: cover;
+	background-position: top;
 }
 
-.primaryDark_ef18ee  {
-	background-color:var(--callbuttons) !important;
+.red_ef18ee {
+	background-color: var(--hangup) !important;
+
+	:hover {
+		filter: brightness(0.8);
+	}
+}
+
+.primaryDark_ef18ee {
+	background-color: var(--callbuttons) !important;
 }
 
 /* Voice Chat */
 .container_adcaac {
-	 background-color:var(--callcolor) !important;
+	background-color: var(--callcolor) !important;
 }
-.buttonColor_adcaac{
-	 background-color:#303C51 !important;
+
+.buttonColor_adcaac {
+	background-color: #303C51 !important;
 }
 
 /* Screenshare */
 .modalSize_e1cc86 {
-	 background-color:var(--callcolor) !important;
+	background-color: var(--callcolor) !important;
 }
 
 /* Emoji/Sticker/GifTab */
 .contentWrapper_af5dbb {
-	 background-color:var(--callcolor) !important;
-}	
-.wrapper_e06857.header_a3bc57 {
-	 background-color:var(--topbar) !important;
-}	
-.inspector_c3120f.inspector_c6ee36 {
-	 background-color:var(--topbar) !important;
-}	
-.inner_effbe2.thin_c49869.scrollerBase_c49869{
-	 background-color:var(--searchbars) !important;
-}	
-.scroller_d53d65.none_c49869.scrollerBase_c49869{
-	 background-color:var(--searchbars) !important;
-}	
-.unicodeShortcut_dfa278{
-	 background-color:var(--searchbars) !important;
-}	
-.categoryItemDefaultCategory_dfa278 {
-	 background-color:var(--searchbars) !important;
-}	
-.stickerCategory_a7a485 {
-	 background-color:var(--searchbars) !important;
-}	
-.wrapper_e06857.packHeader_de4721 {
-		 background-color:var(--topbar) !important;
+	background-color: var(--callcolor) !important;
 }
+
+.wrapper_e06857.header_a3bc57 {
+	background-color: var(--topbar) !important;
+}
+
+.inspector_c3120f.inspector_c6ee36 {
+	background-color: var(--topbar) !important;
+}
+
+.inner_effbe2.thin_c49869.scrollerBase_c49869 {
+	background-color: var(--searchbars) !important;
+}
+
+.scroller_d53d65.none_c49869.scrollerBase_c49869 {
+	background-color: var(--searchbars) !important;
+}
+
+.unicodeShortcut_dfa278 {
+	background-color: var(--searchbars) !important;
+}
+
+.categoryItemDefaultCategory_dfa278 {
+	background-color: var(--searchbars) !important;
+}
+
+.stickerCategory_a7a485 {
+	background-color: var(--searchbars) !important;
+}
+
+.wrapper_e06857.packHeader_de4721 {
+	background-color: var(--topbar) !important;
+}
+
 .standardStickerShortcut_a7a485 {
-	 background-color:var(--topbar) !important;
-}	
+	background-color: var(--topbar) !important;
+}
+
 .inspector_c3120f {
-	 background-color:var(--topbar) !important;
-}	
+	background-color: var(--topbar) !important;
+}
+
 .inner_c18ec9 {
-	 background-color:var(--searchbars) !important;
-}	
+	background-color: var(--searchbars) !important;
+}
+
 .header_b56bbc {
-	 background-color:var(--callcolor) !important;
-}	
+	background-color: var(--callcolor) !important;
+}
+
 .content_b56bbc {
-	 background-color:var(--callcolor) !important;
-}	
+	background-color: var(--callcolor) !important;
+}
 
 
 
@@ -381,81 +317,77 @@ background-color:var(--sidebar) !important;
 
 /* Channel List */
 .container_ee69e0 {
-background-color:var(--sidebar) !important;
-
+	background-color: var(--sidebar) !important;
 }
 
-
-.containerDefault_f6f816.selected_f6f816 .link_d8bfb3  {
+.containerDefault_f6f816.selected_f6f816 .link_d8bfb3 {
 	background-color: #68798D !important;
-	
 }
 
 /* DM List */
-.scroller_c47fa9  {
-background-color:var(--sidebar) !important;
-
-
+.scroller_c47fa9 {
+	background-color: var(--sidebar) !important;
 }
 
 .searchBar_f0963d {
-background-color:var(--sidebar) !important;
+	background-color: var(--sidebar) !important;
 }
 
 .selected_f5eb4b {
 	background-color: #68798D !important;
-	
 }
 
 /* Account container */
 .container_b2ca13 {
-  background-color:var(--momotalkbanner) !important;
+	background-color: var(--momotalkbanner) !important;
 }
-.contents_dd4f85  {
-	color: white;
 
+.contents_dd4f85 {
+	color: white;
 }
 
 /* Message Bar */
 .scrollableContainer_d0696b {
-  background-color:var(--senseimessagebubble);
+	background-color: var(--senseimessagebubble);
 }
-.slateTextArea_e52116   {
+
+.slateTextArea_e52116 {
 	color: white;
 }
 
-.activeButtonChild_a06035  {
+.activeButtonChild_a06035 {
 	color: #EFB7D0;
 }
 
 /* Search Bars */
 .searchBarComponent_f0963d {
-background-color:var(--searchbars) !important;
+	background-color: var(--searchbars) !important;
 }
+
 .searchBar_a46bef {
-background-color:var(--searchbars) !important;
+	background-color: var(--searchbars) !important;
 }
-.searchBar_e0840f  {
-background-color:var(--searchbars) !important;
+
+.searchBar_e0840f {
+	background-color: var(--searchbars) !important;
 }
 
 /* Settings Menu (there is totally a better way of doing this) */
-
 .h1_c46f6a {
-	 color:var(--settingsfontcolor);
+	color: var(--settingsfontcolor);
 }
 
 
 .tabBarItem_bff66b.item_a0.brand_a0.selected_a0 {
-	 color:var(--settingsfontcolor);
+	color: var(--settingsfontcolor);
 }
 
 .vc-settings-tab-bar-item.item_a0.brand_a0.selected_a0 {
-	 color:var(--settingsfontcolor);
+	color: var(--settingsfontcolor);
 }
 
 .vc-settings-card {
-	 color:var(--settingsfontcolor);
+	color: var(--settingsfontcolor);
 }
 
 .formText_b89ec7 {
@@ -463,141 +395,162 @@ background-color:var(--searchbars) !important;
 }
 
 .gameName_fd966d {
-	 color:var(--settingsfontcolor);
+	color: var(--settingsfontcolor);
 }
 
-.formText_b89ec7{
-	 color:var(--settingsfontcolor) !important;
+.formText_b89ec7 {
+	color: var(--settingsfontcolor) !important;
 }
 
 .tab_d8bb15.item_a0.brand_a0.selected_a0 {
-	 color:var(--settingsfontcolor);
+	color: var(--settingsfontcolor);
 }
 
 .settingsTabBarItem_d576e9.item_a0.brand_a0.selected_a0 {
-	 color:var(--settingsfontcolor);
+	color: var(--settingsfontcolor);
 }
 
 .title_ed1d57 {
-	 color:var(--settingsfontcolor);
+	color: var(--settingsfontcolor);
 }
 
 .button_dd4f85.lookOutlined_dd4f85.colorRed_dd4f85.sizeSmall_dd4f85.grow_dd4f85 {
-  /* Your styles here */
-  background-color: #FB94A7;
+	/* Your styles here */
+	background-color: #FB94A7;
 }
 
 .description_b89ec7 {
- color: gray;	
+	color: gray;
 }
 
 /* Other standard color?? scary if you don't know what the second thing in your project really does*/
 .colorStandard_fbc755 {
-	    color:var(--username);
+	color: var(--username);
 }
 
 /*Other colors?*/
 .defaultColor_a595eb {
-color:var(--username);	
+	color: var(--username);
 }
+
 .card_a298b8 {
-background-color:var(--topbar) !important;	
+	background-color: var(--topbar) !important;
 }
+
 .vc-addon-card {
-background-color:var(--topbar) !important;	
+	background-color: var(--topbar) !important;
 }
 
-/* MAKING YOUR MESSAGES FANCY AND TO THE LEFT*/
-/* Self Message container */
-[data-is-self="true"] .contents_f9f2ca .markup_f8f345 {
-  background-color:var(--senseimessagebubble);
-    display: block;
-    width: fit-content;
-    margin-left: auto;
-    margin-right: 30px;
+/* Common Message Container*/
+.message_d5deea {
+	--momo-messages-border-radius: 10px;
+
+	display: flex;
+	flex-direction: column;
+
+	&.groupStart_d5deea::after {
+		content: "\25BA";
+		display: block;
+		position: absolute;
+		color: var(--messagebubble);
+		border-radius: 5px;
+		font-size: 15px;
+	}
+
+	>.contents_f9f2ca {
+		display: flex;
+		flex-direction: column;
+
+		.markup_f8f345.messageContent_f9f2ca {
+			display: inline-block;
+			padding: 5px 15px;
+			margin-left: 0px;
+			max-width: 600px;
+			border-radius: var(--momo-messages-border-radius);
+			background-color: var(--messagebubble);
+
+			&:empty {
+				background-color: transparent;
+				padding: 0;
+			}
+		}
+	}
+
+	.container_b558d0 {
+		background-color: var(--messagebubble);
+		border-radius: var(--momo-messages-border-radius);
+		width: fit-content;
+		padding: 20px 15px;
+	}
 }
 
-/* Move Username */
-[data-is-self="true"] .header_f9f2ca{
-    display: block;
-    width: fit-content;
-    margin-left: auto;
-    margin-right: 25px;
+/* Other Message Container */
+[data-is-self="false"] .message_d5deea {
+	align-items: start;
+
+	&.groupStart_d5deea::after {
+		transform: rotate(180deg);
+		left: 74px;
+		top: 28px;
+	}
+
+	>.contents_f9f2ca {
+		align-items: start;
+
+		.markup_f8f345.messageContent_f9f2ca {
+			margin-left: 11px;
+		}
+	}
+
+	.container_b558d0 {
+		left: 10px;
+	}
 }
 
+/* Self Message Container */
+[data-is-self="true"] .message_d5deea {
+	--messagebubble: var(--senseimessagebubble);
+	align-items: end;
 
-/* Move Profile Pic */
-[data-is-self="true"] .avatar_f9f2ca{
-    left: unset;
-    right: 4px;
-}
+	/* Flip discord paddings */
+	padding-right: var(--custom-message-margin-left-content-cozy) !important;
+	padding-left: 48px;
 
-/* Move Decoration */
-[data-is-self="true"] .avatarDecoration_f9f2ca{
-    left: unset;
-    right: 0px;
-}
-
-
-/* Self Little arrow in message containers */
-[data-is-self="true"] .groupStart_d5deea::after {
-  color:var(--senseimessagebubble);
-    content: "\25BA";
-    font-size: 15px;
-    display: block;
-    transform: rotate(0deg);
-    position: absolute;
-    right: 69px; /* Align to the right */
-    top: 30px;
-    border-radius: 4px;
-}
-
-/* Self Little arrow for calls?? idk*/
-[data-is-self="true"] .isSystemMessage_f9f2ca::after {
-  color:transparent;
-    content: "\25BA";
-    font-size: 15px;
-    display: block;
-    transform: rotate(0deg);
-    position: absolute;
-    right: 9px; /* Align to the right */
-    top: 30px;
-    border-radius: 4px;
-}
-
-/* Little arrow in message containers for replies! */
-[data-is-self="true"] .hasReply_f9f2ca::after {
-
-    content: "\25BA";
-  color:var(--senseimessagebubble);
-    font-size: 15px;
-    display: block;
-    transform: rotate(0deg);
-    position: absolute;
-    right: 69px; 
-    top: 53px;
-    border-radius: 4px;
-}
-
-/* Self Message container for images */
- .container_b558d0 {
-  background-color:var(--senseimessagebubble);
-    width: fit-content;
-    border-radius: 10px;
-    padding: 5px 15px; 
-    padding-top: 25px;
-    padding-bottom: 20px;
-    margin-bottom: -20px;
-    margin-left: auto;
-    margin-right: 30px;
-    bottom: 10px;
-}
+	&.groupStart_d5deea::after {
+		transform: rotate(0deg);
+		right: 70px;
+		top: 30px;
+	}
 
 
-/* Trying to make replies appear right auwfigdfuighdfudg (that actually was suprisingly easy wow! hey, what are you doing all the way here?!!) */
-[data-is-self="true"] .repliedMessage_f9f2ca {
+	>.contents_f9f2ca {
+		align-items: end;
 
-    width: fit-content;
-    margin-left: auto;
-    margin-right: 30px;	
+		img.avatar_f9f2ca {
+			left: initial;
+			right: var(--custom-message-margin-horizontal);
+		}
+
+		.markup_f8f345.messageContent_f9f2ca {
+			right: 8px;
+		}
+	}
+
+	.container_b558d0 {
+		right: 8px;
+	}
+
+	.timestamp_f9f2ca {
+		left: initial;
+		right: 0;
+	}
+
+	.buttonContainer_f9f2ca {
+		right: initial;
+		left: 0px;
+
+		>div {
+			right: initial;
+		}
+	}
 }

--- a/MomotalkSource.theme.css
+++ b/MomotalkSource.theme.css
@@ -477,7 +477,8 @@
 	}
 
 	.container_b558d0 {
-		background-color: var(--messagebubble);
+		background-color: transparent;
+		border: 1px solid var(--messagebubble);
 		border-radius: var(--momo-messages-border-radius);
 		width: fit-content;
 		padding: 20px 15px;

--- a/MomotalkSource.theme.css
+++ b/MomotalkSource.theme.css
@@ -71,9 +71,6 @@
 .typing_d7ebeb {
  color:var(--username); 	
 }
-.typingDots_d7ebeb {
- backgcolor:var(--username); 	
-}
 
 /* Custom Background Image */
 .chatContent_a7d72e {
@@ -90,7 +87,7 @@
 
 /* Usernames */
 .username_f9f2ca{
-    color:var(--username); !important; 
+    color:var(--username) !important; 
         font-weight: bold;
         margin-left: 8px;
 
@@ -229,7 +226,7 @@ display:none;
 		background-color: #E7F0F7;
 }
 .username_f3939d{
-	color: #3A4446; !important
+	color: #3A4446 !important;
 }
 
 .scroller_bf550a {
@@ -255,7 +252,7 @@ display:none;
 }
 
 .scroller_e2e187::-webkit-scrollbar-thumb {
-    background-col: #B0B0B0; 
+    background-color: #B0B0B0; 
     border-radius: 8px; 
 }
 

--- a/MomotalkSource.theme.css
+++ b/MomotalkSource.theme.css
@@ -471,7 +471,6 @@
 
 		.markup_f8f345 {
 			padding: 5px 15px;
-			margin-left: 0px;
 			max-width: 600px;
 			border-radius: var(--momo-messages-border-radius);
 			background-color: var(--messagebubble);
@@ -479,7 +478,7 @@
 		}
 	}
 
-	&:has(>.contents_f9f2ca>.markup_f8f345.messageContent_f9f2ca:empty)>.container_b558d0 {
+	&:has(>.contents_f9f2ca>.markup_f8f345:empty)>.container_b558d0 {
 		top: initial;
 	}
 
@@ -522,14 +521,8 @@
 	}
 
 	/* Border handling for messages with content attached */
-	&:has(.container_b558d0>:not(.reactions_ec6b19)) {
-		.contents_f9f2ca>.markup_f8f345 {
-			border-bottom-left-radius: 0;
-		}
-
-		&:has(>.contents_f9f2ca>.markup_f8f345.messageContent_f9f2ca:not(:empty))>.container_b558d0 {
-			border-top-left-radius: 0;
-		}
+	&:has(.container_b558d0>:not(.reactions_ec6b19)) .contents_f9f2ca>.markup_f8f345 {
+		border-bottom-left-radius: 0;
 	}
 }
 
@@ -579,14 +572,8 @@
 	}
 
 	/* Border handling for messages with content attached */
-	&:has(.container_b558d0>:not(.reactions_ec6b19)) {
-		.contents_f9f2ca>.markup_f8f345 {
-			border-bottom-right-radius: 0;
-		}
-
-		&:has(>.contents_f9f2ca>.markup_f8f345.messageContent_f9f2ca:not(:empty))>.container_b558d0 {
-			border-top-right-radius: 0;
-		}
+	&:has(.container_b558d0>:not(.reactions_ec6b19)) .contents_f9f2ca>.markup_f8f345 {
+		border-bottom-right-radius: 0;
 	}
 
 	/* Very hacky way of fixing the reply "glyph" */

--- a/MomotalkSource.theme.css
+++ b/MomotalkSource.theme.css
@@ -144,7 +144,6 @@
 
 /*Links Color*/
 
-
 /* Friends Tab */
 .theme-dark.images-dark.container_fc4f04.themed_fc4f04 {
 	background-color: #E7F0F7;
@@ -208,7 +207,6 @@
 .icon_fc4f04 {
 	color: #4ABDD8;
 }
-
 
 /* Server list */
 .scroller_fea3ef {
@@ -311,10 +309,6 @@
 	background-color: var(--callcolor) !important;
 }
 
-
-
-
-
 /* Channel List */
 .container_ee69e0 {
 	background-color: var(--sidebar) !important;
@@ -376,7 +370,6 @@
 .h1_c46f6a {
 	color: var(--settingsfontcolor);
 }
-
 
 .tabBarItem_bff66b.item_a0.brand_a0.selected_a0 {
 	color: var(--settingsfontcolor);
@@ -448,10 +441,12 @@
 	display: flex;
 	flex-direction: column;
 
-	&.groupStart_d5deea::after {
+	/* Message reply arrow*/
+	&.groupStart_d5deea>.contents_f9f2ca>.markup_f8f345::after,
+	&.isSystemMessage_f9f2ca>.contents_f9f2ca>.markup_f8f345::after {
 		content: "\25BA";
-		display: block;
 		position: absolute;
+		top: 3px;
 		color: var(--messagebubble);
 		border-radius: 5px;
 		font-size: 15px;
@@ -468,6 +463,7 @@
 			max-width: 600px;
 			border-radius: var(--momo-messages-border-radius);
 			background-color: var(--messagebubble);
+			overflow: visible;
 
 			&:empty {
 				background-color: transparent;
@@ -477,11 +473,10 @@
 	}
 
 	.container_b558d0 {
-		background-color: transparent;
-		border: 1px solid var(--messagebubble);
+		background-color: var(--messagebubble);
 		border-radius: var(--momo-messages-border-radius);
 		width: fit-content;
-		padding: 20px 15px;
+		padding: 20px;
 	}
 }
 
@@ -489,18 +484,17 @@
 [data-is-self="false"] .message_d5deea {
 	align-items: start;
 
-	&.groupStart_d5deea::after {
-		transform: rotate(180deg);
-		left: 74px;
-		top: 28px;
-	}
-
 	>.contents_f9f2ca {
 		align-items: start;
 
-		.markup_f8f345.messageContent_f9f2ca {
+		.markup_f8f345 {
 			margin-left: 11px;
 			left: 2px;
+
+			&::after {
+				transform: rotate(180deg);
+				left: -11px;
+			}
 		}
 	}
 
@@ -522,13 +516,6 @@
 		padding-right: var(--custom-message-margin-left-content-cozy) !important;
 	}
 
-	&.groupStart_d5deea::after {
-		transform: rotate(0deg);
-		right: 70px;
-		top: 30px;
-	}
-
-
 	>.contents_f9f2ca {
 		align-items: end;
 
@@ -539,6 +526,10 @@
 
 		.markup_f8f345.messageContent_f9f2ca {
 			right: 9px;
+
+			&::after {
+				right: -11px;
+			}
 		}
 	}
 
@@ -557,6 +548,31 @@
 
 		>div {
 			right: initial;
+		}
+	}
+
+	/* Very hacky way of fixing the reply "glyph" */
+	.repliedMessage_f9f2ca {
+		&::before {
+			display: none;
+		}
+
+		&::after {
+			--spine-width: 2px;
+			content: "";
+			display: block;
+			position: absolute;
+			box-sizing: border-box;
+			top: 45%;
+			right: -36px;
+			width: 33px;
+			height: 12px;
+			bottom: 0;
+			border-color: var(--interactive-muted);
+			border-width: var(--spine-width) 0 0 var(--spine-width);
+			border-style: solid;
+			border-top-left-radius: 6px;
+			transform: scaleX(-100%);
 		}
 	}
 }

--- a/MomotalkSource.theme.css
+++ b/MomotalkSource.theme.css
@@ -167,15 +167,15 @@
 
 /* Scrollbar */
 .scroller_e2e187 {
-	::-webkit-scrollbar {
+	&::-webkit-scrollbar {
 		width: 15px;
 	}
 
-	::-webkit-scrollbar-track {
+	&::-webkit-scrollbar-track {
 		background-color: #E1E4E6;
 	}
 
-	::-webkit-scrollbar-thumb {
+	&::-webkit-scrollbar-thumb {
 		background-color: #B0B0B0;
 		border-radius: 8px;
 	}

--- a/MomotalkSource.theme.css
+++ b/MomotalkSource.theme.css
@@ -442,14 +442,22 @@
 	flex-direction: column;
 
 	/* Message reply arrow*/
-	&.groupStart_d5deea>.contents_f9f2ca>.markup_f8f345::after,
-	&.isSystemMessage_f9f2ca>.contents_f9f2ca>.markup_f8f345::after {
+	&.groupStart_d5deea>.contents_f9f2ca::after,
+	&.isSystemMessage_f9f2ca>.contents_f9f2ca::after {
 		content: "\25BA";
 		position: absolute;
-		top: 3px;
 		color: var(--messagebubble);
 		border-radius: 5px;
 		font-size: 15px;
+	}
+	&.groupStart_d5deea>.contents_f9f2ca::after {
+		top: 30px;
+	}
+	&.groupStart_d5deea.hasReply_f9f2ca>.contents_f9f2ca::after {
+		top: 53px;
+	}
+	&.isSystemMessage_f9f2ca>.contents_f9f2ca::after {
+		top: 9px;
 	}
 
 	>.contents_f9f2ca {

--- a/MomotalkSource.theme.css
+++ b/MomotalkSource.theme.css
@@ -465,7 +465,6 @@
 		flex-direction: column;
 
 		.markup_f8f345 {
-			display: inline-block;
 			padding: 5px 15px;
 			margin-left: 0px;
 			max-width: 600px;
@@ -481,9 +480,13 @@
 	}
 
 	.container_b558d0 {
+		display: flex;
+		flex-direction: column;
+		align-items: end;
 		padding: 0;
 	
-		>.visualMediaItemContainer_cda674, .inlineMediaEmbed_b0068a {
+		>:not(.reactions_ec6b19) {
+			align-self: flex-end;
 			height: initial;
 			background-color: var(--messagebubble);
 			border-radius: var(--momo-messages-border-radius);
@@ -505,18 +508,28 @@
 		align-items: start;
 
 		.markup_f8f345 {
-			margin-left: 11px;
-			left: 2px;
+			margin-left: 13px;
+		}
 
-			&::after {
-				transform: rotate(180deg);
-				left: -11px;
-			}
+		&::after {
+			left: 74px;
+			transform: rotate(180deg);
 		}
 	}
 
 	.container_b558d0 {
-		left: 13px;
+		margin-left: 13px;
+	}
+
+	/* Border handling for messages with content attached */
+	&:has(.container_b558d0>:not(.reactions_ec6b19)) {
+		.contents_f9f2ca>.markup_f8f345 {
+			border-radius: var(--momo-messages-border-radius) var(--momo-messages-border-radius) var(--momo-messages-border-radius) 0;
+		}
+
+		&:has(>.contents_f9f2ca>.markup_f8f345.messageContent_f9f2ca:not(:empty))>.container_b558d0>:not(.reactions_ec6b19) {
+			border-radius: 0 var(--momo-messages-border-radius) var(--momo-messages-border-radius);
+		}
 	}
 }
 
@@ -534,7 +547,9 @@
 	}
 
 	>.contents_f9f2ca {
+		margin-right: 9px;
 		align-items: end;
+		flex: 1;
 
 		img.avatar_f9f2ca {
 			left: initial;
@@ -542,16 +557,16 @@
 		}
 
 		.markup_f8f345 {
-			right: 9px;
+			flex: 1;
+		}
 
-			&::after {
-				right: -11px;
-			}
+		&::after {
+			right: 70px;
 		}
 	}
 
 	.container_b558d0 {
-		right: 9px;
+		margin-right: 9px;
 	}
 
 	.timestamp_f9f2ca {
@@ -559,12 +574,24 @@
 		right: 0;
 	}
 
+	/* Switch end buttons appears to avoid covering text */
 	.buttonContainer_f9f2ca {
 		right: initial;
 		left: 0px;
 
 		>div {
 			right: initial;
+		}
+	}
+
+	/* Border handling for messages with content attached */
+	&:has(.container_b558d0>:not(.reactions_ec6b19)) {
+		.contents_f9f2ca>.markup_f8f345 {
+			border-radius: var(--momo-messages-border-radius) var(--momo-messages-border-radius) 0;
+		}
+
+		&:has(>.contents_f9f2ca>.markup_f8f345.messageContent_f9f2ca:not(:empty))>.container_b558d0>:not(.reactions_ec6b19) {
+			border-radius: var(--momo-messages-border-radius) 0 var(--momo-messages-border-radius) var(--momo-messages-border-radius);
 		}
 	}
 

--- a/MomotalkSource.theme.css
+++ b/MomotalkSource.theme.css
@@ -450,19 +450,24 @@
 		border-radius: 5px;
 		font-size: 15px;
 	}
+
 	&.groupStart_d5deea>.contents_f9f2ca::after {
 		top: 30px;
 	}
+
 	&.groupStart_d5deea.hasReply_f9f2ca>.contents_f9f2ca::after {
 		top: 53px;
 	}
+
 	&.isSystemMessage_f9f2ca>.contents_f9f2ca::after {
 		top: 9px;
 	}
 
 	>.contents_f9f2ca {
 		display: flex;
+		align-items: inherit;
 		flex-direction: column;
+		z-index: 1;
 
 		.markup_f8f345 {
 			padding: 5px 15px;
@@ -471,31 +476,28 @@
 			border-radius: var(--momo-messages-border-radius);
 			background-color: var(--messagebubble);
 			overflow: visible;
-
-			&:empty {
-				background-color: transparent;
-				padding: 0;
-			}
 		}
 	}
 
-	.container_b558d0 {
-		display: flex;
-		flex-direction: column;
-		align-items: end;
-		padding: 0;
-	
-		>:not(.reactions_ec6b19) {
-			align-self: flex-end;
-			height: initial;
-			background-color: var(--messagebubble);
-			border-radius: var(--momo-messages-border-radius);
-			width: fit-content;
-			padding: 20px;
-		}
+	&:has(>.contents_f9f2ca>.markup_f8f345.messageContent_f9f2ca:empty)>.container_b558d0 {
+		top: initial;
+	}
 
-		.reaction_ec6b19.reactionMe_ec6b19 .reactionCount_ec6b19 {
-			color: var(--brand-560);
+	.container_b558d0 {
+		background-color: var(--messagebubble);
+		border-radius: var(--momo-messages-border-radius);
+		width: fit-content;
+		top: -9px;
+		padding: 20px;
+
+		&:has(:first-child.reactions_ec6b19) {
+			top: initial;
+			padding: 0;
+			background-color: transparent;
+
+			.reaction_ec6b19.reactionMe_ec6b19 .reactionCount_ec6b19 {
+				color: var(--brand-560);
+			}
 		}
 	}
 }
@@ -505,14 +507,12 @@
 	align-items: start;
 
 	>.contents_f9f2ca {
-		align-items: start;
-
 		.markup_f8f345 {
 			margin-left: 13px;
 		}
 
 		&::after {
-			left: 74px;
+			left: 75px;
 			transform: rotate(180deg);
 		}
 	}
@@ -524,11 +524,11 @@
 	/* Border handling for messages with content attached */
 	&:has(.container_b558d0>:not(.reactions_ec6b19)) {
 		.contents_f9f2ca>.markup_f8f345 {
-			border-radius: var(--momo-messages-border-radius) var(--momo-messages-border-radius) var(--momo-messages-border-radius) 0;
+			border-bottom-left-radius: 0;
 		}
 
-		&:has(>.contents_f9f2ca>.markup_f8f345.messageContent_f9f2ca:not(:empty))>.container_b558d0>:not(.reactions_ec6b19) {
-			border-radius: 0 var(--momo-messages-border-radius) var(--momo-messages-border-radius);
+		&:has(>.contents_f9f2ca>.markup_f8f345.messageContent_f9f2ca:not(:empty))>.container_b558d0 {
+			border-top-left-radius: 0;
 		}
 	}
 }
@@ -548,20 +548,14 @@
 
 	>.contents_f9f2ca {
 		margin-right: 9px;
-		align-items: end;
-		flex: 1;
 
 		img.avatar_f9f2ca {
 			left: initial;
 			right: var(--custom-message-margin-horizontal);
 		}
 
-		.markup_f8f345 {
-			flex: 1;
-		}
-
 		&::after {
-			right: 70px;
+			right: 71px;
 		}
 	}
 
@@ -587,11 +581,11 @@
 	/* Border handling for messages with content attached */
 	&:has(.container_b558d0>:not(.reactions_ec6b19)) {
 		.contents_f9f2ca>.markup_f8f345 {
-			border-radius: var(--momo-messages-border-radius) var(--momo-messages-border-radius) 0;
+			border-bottom-right-radius: 0;
 		}
 
-		&:has(>.contents_f9f2ca>.markup_f8f345.messageContent_f9f2ca:not(:empty))>.container_b558d0>:not(.reactions_ec6b19) {
-			border-radius: var(--momo-messages-border-radius) 0 var(--momo-messages-border-radius) var(--momo-messages-border-radius);
+		&:has(>.contents_f9f2ca>.markup_f8f345.messageContent_f9f2ca:not(:empty))>.container_b558d0 {
+			border-top-right-radius: 0;
 		}
 	}
 


### PR DESCRIPTION
### Fixes
 - Message overlaps when content attachments are present.
 - Weird looking border radius for messages with content attachments and texts.
 - Reply "glyph" pointing to empty space when replying to a message.
 - Remove background and padding for reactions on text only messages.
 - Re-add phone icon on call system messages.
 - Fix some incorrect CSS attributes.

### Changes
 - Move timestamps of own messages to right.
 - Move action button of own messages to left.

### Comments

I've taken the liberty of rewriting the message box's styles using nested selectors instead of duplicating selectors and rules.
Most of the edits through the file are from VSCode auto formatting the document after editing. It makes the changes from this PR hard to see, but I consider it a necessary evil for code clarity and future contributions.

### Screenshots

Reply glyph
![Screenshot_20240809_062806](https://github.com/user-attachments/assets/27ec034e-1032-4362-a917-b21e627b609a)
Content attachment border with text radius, reactions
![Screenshot_20240809_062846](https://github.com/user-attachments/assets/047be5aa-65cb-4547-bbad-fffc5ae4edfd)
Content attachment overlapping with messages, reactions, moved own message timestamps
![Screenshot_20240809_062831](https://github.com/user-attachments/assets/6c5f7755-101e-4cc5-b866-b80a6c701cc0)
